### PR TITLE
Store ONNX files in Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-chimp_chomp/chimp.onnx filter=lfs diff=lfs merge=lfs -text
+*.onnx filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
The `.gitattributes` path for the CHiMP ONNX file was not updated as part of #110, this PR changes the `.gitattributes` rule to store any `.onnx` file in the repository with Git LFS