### PR TITLE
Use templating for pin-packing opa url

### DIFF
--- a/charts/xchemlab/Chart.lock
+++ b/charts/xchemlab/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.1
 - name: pin-packing
   repository: ""
-  version: 0.0.1
+  version: 0.0.2
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.58.8
@@ -29,5 +29,5 @@ dependencies:
 - name: oauth2-proxy
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 3.7.4
-digest: sha256:24e8fef3d198766bf837c3f3c421c7e35642467d3868fb703976cebf1a3c2a3e
-generated: "2023-09-19T09:41:25.741976127+01:00"
+digest: sha256:5bf432b6cd6218e1f65410a5881a1bbd9135549ec237213ac84b1e08e044424e
+generated: "2023-10-02T13:09:43.22687347+01:00"

--- a/charts/xchemlab/Chart.yaml
+++ b/charts/xchemlab/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -19,7 +19,7 @@ dependencies:
     version: 0.0.1
     condition: chimp-chomp.enabled
   - name: pin-packing
-    version: 0.0.1
+    version: 0.0.2
     condition: pin-packing.enabled
   - name: grafana
     repository: https://grafana.github.io/helm-charts

--- a/charts/xchemlab/charts/pin-packing/Chart.yaml
+++ b/charts/xchemlab/charts/pin-packing/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/xchemlab/charts/pin-packing/templates/_helpers.tpl
+++ b/charts/xchemlab/charts/pin-packing/templates/_helpers.tpl
@@ -71,11 +71,3 @@ Create the database URL string
 {{- $raw_database_url := urlJoin $url_parts }}
 {{- replace "$DATABASE_PASSWORD" "$(DATABASE_PASSWORD)" $raw_database_url }}
 {{- end }}
-
-{{/*
-Create the OPA URL string
-*/}}
-{{- define "pinPacking.opaURL" -}}
-{{- $host := printf "%s-%s:8181" .Release.Name .Values.opa.serviceSuffix }}
-{{- urlJoin ( dict "scheme" "http" "host" $host ) }}
-{{- end }}

--- a/charts/xchemlab/charts/pin-packing/templates/deployment.yaml
+++ b/charts/xchemlab/charts/pin-packing/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - name: DATABASE_URL
               value: {{ include "pinPacking.databaseURL" . }}
             - name: OPA_URL
-              value: {{ include "pinPacking.opaURL" . }}
+              value: {{ tpl .Values.opa.url . }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/xchemlab/charts/pin-packing/values.yaml
+++ b/charts/xchemlab/charts/pin-packing/values.yaml
@@ -16,7 +16,7 @@ database:
     secretKey: ""
 
 opa:
-  serviceSuffix: ""
+  url: ""
 
 replicaCount: 1
 

--- a/charts/xchemlab/values.yaml
+++ b/charts/xchemlab/values.yaml
@@ -28,7 +28,7 @@ pin-packing:
       secretName: postgres-passwords
       secretKey: password
   opa:
-    serviceSuffix: opa-kube-mgmt
+    url: http://{{ .Release.Name }}-opa-kube-mgmt:8181
 
 grafana:
   enabled: true


### PR DESCRIPTION
Simplifies the process of deriving the Open Policy Agent URL in the `pin-packing` helm chart by allowing the use of GO template strings in the `opa.url` field