### PR TITLE
Remove `.env` file mount from OPA dev container

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -22,8 +22,6 @@ services:
       - --server
       - --watch
       - /policies
-    env_file:
-      - .env
 
   postgres:
     image: docker.io/library/postgres:15.3-bookworm


### PR DESCRIPTION
No secret environment variables are required for the operation of the Open Policy Agent (OPA) dev container. This PR removes it from the `docker-compose` configuration