### PR TITLE
Bump chart application versions to `0.0.5`

### DIFF
--- a/charts/xchemlab/Chart.lock
+++ b/charts/xchemlab/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: chimp-chomp
   repository: ""
-  version: 0.0.1
+  version: 0.0.2
 - name: pin-packing
   repository: ""
-  version: 0.0.2
+  version: 0.0.3
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.58.8
@@ -29,5 +29,5 @@ dependencies:
 - name: oauth2-proxy
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 3.7.4
-digest: sha256:5bf432b6cd6218e1f65410a5881a1bbd9135549ec237213ac84b1e08e044424e
-generated: "2023-10-02T13:09:43.22687347+01:00"
+digest: sha256:61a4a1de659356a61696bea15c5b916b8e85cb297162f689c435a50357869c44
+generated: "2023-10-02T13:37:21.504008114+01:00"

--- a/charts/xchemlab/Chart.yaml
+++ b/charts/xchemlab/Chart.yaml
@@ -6,20 +6,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "0.1.0"
+version: 0.3.0
 
 dependencies:
   - name: chimp-chomp
-    version: 0.0.1
+    version: 0.0.2
     condition: chimp-chomp.enabled
   - name: pin-packing
-    version: 0.0.2
+    version: 0.0.3
     condition: pin-packing.enabled
   - name: grafana
     repository: https://grafana.github.io/helm-charts

--- a/charts/xchemlab/charts/chimp-chomp/Chart.yaml
+++ b/charts/xchemlab/charts/chimp-chomp/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.4"
+appVersion: "0.0.5"

--- a/charts/xchemlab/charts/pin-packing/Chart.yaml
+++ b/charts/xchemlab/charts/pin-packing/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.4"
+appVersion: "0.0.5"


### PR DESCRIPTION
Updates the helm chart to use the most current application releases (`0.0.5`)