### PR TITLE
Pass chimp chomp `RabbitMQ` URL in as env var

### DIFF
--- a/charts/xchemlab/Chart.lock
+++ b/charts/xchemlab/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: chimp-chomp
   repository: ""
-  version: 0.0.2
+  version: 0.0.3
 - name: pin-packing
   repository: ""
   version: 0.0.3
@@ -29,5 +29,5 @@ dependencies:
 - name: oauth2-proxy
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 3.7.4
-digest: sha256:61a4a1de659356a61696bea15c5b916b8e85cb297162f689c435a50357869c44
-generated: "2023-10-02T13:37:21.504008114+01:00"
+digest: sha256:ec1bf648ac55ba660a18615b0fecd6d424381798e22af00cc942a57368fdeb25
+generated: "2023-10-02T16:53:21.46515017+01:00"

--- a/charts/xchemlab/Chart.yaml
+++ b/charts/xchemlab/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 dependencies:
   - name: chimp-chomp
-    version: 0.0.2
+    version: 0.0.3
     condition: chimp-chomp.enabled
   - name: pin-packing
     version: 0.0.3

--- a/charts/xchemlab/charts/chimp-chomp/Chart.yaml
+++ b/charts/xchemlab/charts/chimp-chomp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/xchemlab/charts/chimp-chomp/templates/deployment.yaml
+++ b/charts/xchemlab/charts/chimp-chomp/templates/deployment.yaml
@@ -36,14 +36,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "$(RABBITMQ_URL)" 
-            - {{ include "chimpChomp.queueChannel" . }}
+            - "$(RABBITMQ_URL)"
+            - "$(RABBITMQ_CHANNEL)"
           env:
             - name: RABBITMQ_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ include "chimpChomp.queueHostSecretName" . }} 
                   key: {{ .Values.queue.host.secretKey }}
+            - name: RABBITMQ_CHANNEL
+              value: {{ include "chimpChomp.queueChannel" . }}
           volumeMounts:
             {{- toYaml .Values.containerVolumeMounts | nindent 12 }}
           resources:


### PR DESCRIPTION
Pass the `RabbitMQ` URL to the chimp chomp container as an environment variable to improve introspectability