### PR TITLE
[`chimp_protocol`] Return predictions as integers

### DIFF
--- a/backend/chimp_chomp/src/postprocessing.rs
+++ b/backend/chimp_chomp/src/postprocessing.rs
@@ -68,18 +68,18 @@ fn optimal_insert_position(insertion_mask: Mat) -> Result<Point, anyhow::Error> 
         .max_by(|(_, a), (_, b)| a.cmp(b))
         .context("No valid insertion points")?;
     Ok(Point {
-        x: furthest_point.x as usize,
-        y: furthest_point.y as usize,
+        x: furthest_point.x,
+        y: furthest_point.y,
     })
 }
 
 /// Converts an [`ArrayView<f32, Ix1>`] of length 4 into a [`BBox`] according to the layout of a MaskRCNN box prediction.
 fn bbox_from_array(bbox: ArrayView<f32, Ix1>) -> BBox {
     BBox {
-        left: bbox[0],
-        top: bbox[1],
-        right: bbox[2],
-        bottom: bbox[3],
+        left: bbox[0] as i32,
+        top: bbox[1] as i32,
+        right: bbox[2] as i32,
+        bottom: bbox[3] as i32,
     }
 }
 

--- a/backend/chimp_chomp/src/well_centering.rs
+++ b/backend/chimp_chomp/src/well_centering.rs
@@ -36,10 +36,10 @@ fn find_well_location(image: WellImage) -> Result<Circle, anyhow::Error> {
         .context("No circles found in image")?;
     Ok(Circle {
         center: Point {
-            x: well_location[0] as usize,
-            y: well_location[1] as usize,
+            x: well_location[0] as i32,
+            y: well_location[1] as i32,
         },
-        radius: well_location[2],
+        radius: well_location[2] as i32,
     })
 }
 
@@ -113,6 +113,6 @@ mod tests {
             location.center.y as f64,
             max_relative = 8.0
         );
-        assert_relative_eq!(RADIUS, location.radius, max_relative = 8.0)
+        assert_relative_eq!(RADIUS, location.radius as f32, max_relative = 8.0)
     }
 }

--- a/backend/chimp_protocol/src/lib.rs
+++ b/backend/chimp_protocol/src/lib.rs
@@ -67,9 +67,9 @@ impl Response {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Point {
     /// The position of the point in the X axis.
-    pub x: usize,
+    pub x: i32,
     /// The position of the point in the Y axis.
-    pub y: usize,
+    pub y: i32,
 }
 
 /// A circle, defined by the center point and radius.
@@ -78,18 +78,18 @@ pub struct Circle {
     /// The position of the circles center.
     pub center: Point,
     /// The radius of the circle.
-    pub radius: f32,
+    pub radius: i32,
 }
 
 /// A bounding box which encompasing a region.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BBox {
     /// The position of the upper bound in the Y axis.
-    pub top: f32,
+    pub top: i32,
     /// The position of the lower bound in the Y axis.
-    pub bottom: f32,
+    pub bottom: i32,
     /// The position of the upper bound in the X axis.
-    pub right: f32,
+    pub right: i32,
     /// The position of the lower bound in the X axis.
-    pub left: f32,
+    pub left: i32,
 }


### PR DESCRIPTION
Return CHiMP predictions as integer types, such that they are consistent with those stored in the `targeting` service