### PR TITLE
[`graphql_endpoints`] Forward authoriztion token in `GraphQLSubscription`

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1638,7 +1638,9 @@ dependencies = [
  "async-graphql",
  "async-graphql-axum",
  "axum",
+ "futures-core",
  "opa_client",
+ "tower-service",
  "url",
 ]
 

--- a/backend/graphql_endpoints/Cargo.toml
+++ b/backend/graphql_endpoints/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2021"
 async-graphql = { workspace = true }
 async-graphql-axum = { version = "5.0.10" }
 axum = { workspace = true }
+futures-core = { version = "0.3.28" }
 opa_client = { path = "../opa_client" }
+tower-service = { version = "0.3.2" }
 
 [dev-dependencies]
 url = { workspace = true }


### PR DESCRIPTION
Previously the `Authorization` token was not passed into the GraphQL context during evaluation of a subscription endpoint. This caused authorization errors when a subscriber accessed a field which required authoirzation. This has been resolved by passing the token as is done with the HTTP endpoint