### PR TITLE
Consistently name plate & well in across API

### DIFF
--- a/backend/chimp_chomp/src/jobs.rs
+++ b/backend/chimp_chomp/src/jobs.rs
@@ -138,7 +138,8 @@ pub async fn produce_response(
             response_target.reply_to.as_str(),
             BasicPublishOptions::default(),
             &Response::Success {
-                job_id: request.id,
+                plate: request.plate,
+                well: request.well,
                 insertion_point: contents.insertion_point,
                 well_location,
                 drop: contents.drop,
@@ -173,7 +174,8 @@ pub async fn produce_error(
             response_target.reply_to.as_str(),
             BasicPublishOptions::default(),
             &Response::Failure {
-                job_id: request.id,
+                plate: request.plate,
+                well: request.well,
                 error: error.to_string(),
             }
             .to_vec()

--- a/backend/chimp_chomp/src/main.rs
+++ b/backend/chimp_chomp/src/main.rs
@@ -114,32 +114,32 @@ async fn run(args: Cli) {
             biased;
 
             Some((response_target, request)) = response_target_rx.recv() => {
-                response_targets.insert(request.id, response_target);
+                response_targets.insert((request.plate, request.well), response_target);
             }
 
             Some((error, request)) = error_rx.recv() => {
-                let response_target = response_targets.remove(&request.id).unwrap();
+                let response_target = response_targets.remove(&(request.plate, request.well)).unwrap();
                 tasks.spawn(produce_error(request, response_target, error, response_channel.clone()));
             }
 
             Some((well_location, request)) = well_location_rx.recv() => {
-                if response_targets.contains_key(&request.id) {
-                    if let Some(contents) = well_contents.remove(&request.id) {
-                        let response_target = response_targets.remove(&request.id).unwrap();
+                if response_targets.contains_key(&(request.plate, request.well)) {
+                    if let Some(contents) = well_contents.remove(&(request.plate, request.well)) {
+                        let response_target = response_targets.remove(&(request.plate, request.well)).unwrap();
                         tasks.spawn(produce_response(request, response_target, contents, well_location, response_channel.clone()));
                     } else {
-                        well_locations.insert(request.id, well_location);
+                        well_locations.insert((request.plate, request.well), well_location);
                     }
                 }
             }
 
             Some((contents, request)) = contents_rx.recv() => {
-                if response_targets.contains_key(&request.id) {
-                    if let Some(well_location) = well_locations.remove(&request.id) {
-                        let response_target = response_targets.remove(&request.id).unwrap();
+                if response_targets.contains_key(&(request.plate, request.well)) {
+                    if let Some(well_location) = well_locations.remove(&(request.plate, request.well)) {
+                        let response_target = response_targets.remove(&(request.plate, request.well)).unwrap();
                         tasks.spawn(produce_response(request, response_target, contents, well_location, response_channel.clone()));
                     } else {
-                        well_contents.insert(request.id, contents);
+                        well_contents.insert((request.plate, request.well), contents);
                     }
                 }
             }

--- a/backend/chimp_protocol/src/lib.rs
+++ b/backend/chimp_protocol/src/lib.rs
@@ -9,8 +9,10 @@ use uuid::Uuid;
 /// A CHiMP processing request definition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Request {
-    /// A unique identifier for the request, to be returned in the [`Response`].
-    pub id: Uuid,
+    /// The plate of the imaged well.
+    pub plate: Uuid,
+    /// The number of the imaged well.
+    pub well: i32,
     /// The pre-signed URL of an object containing the image to perform inference on.
     pub download_url: Url,
 }
@@ -32,8 +34,10 @@ impl Request {
 pub enum Response {
     /// The image was processed successfully, producing the contained predictions.
     Success {
-        /// The unique identifier of the [`Request`].
-        job_id: Uuid,
+        /// The plate of the imaged well.
+        plate: Uuid,
+        /// The number of the imaged well.
+        well: i32,
         /// The proposed point for solvent insertion.
         insertion_point: Point,
         /// The location of the well centroid and radius.
@@ -45,8 +49,10 @@ pub enum Response {
     },
     /// Image processing failed, with the contained error.
     Failure {
-        /// The unique identifier of the [`Request`].
-        job_id: Uuid,
+        /// The plate of the imaged well.
+        plate: Uuid,
+        /// The number of the imaged well.
+        well: i32,
         /// A description of the error encountered.
         error: String,
     },

--- a/backend/pin_packing/src/resolvers/crystal.rs
+++ b/backend/pin_packing/src/resolvers/crystal.rs
@@ -52,8 +52,8 @@ impl CrystalMutation {
         let database = ctx.data::<DatabaseConnection>()?;
         let crystal = crystal::ActiveModel {
             id: ActiveValue::Set(Uuid::new_v4()),
-            plate_id: ActiveValue::Set(well.plate),
-            well_number: ActiveValue::Set(well.well),
+            plate: ActiveValue::Set(well.plate),
+            well: ActiveValue::Set(well.well),
             crystal_state: ActiveValue::Set(crystal_state),
             compound_state: ActiveValue::Set(compound_state),
             timestamp: ActiveValue::Set(Utc::now()),

--- a/backend/pin_packing/src/tables/crystal.rs
+++ b/backend/pin_packing/src/tables/crystal.rs
@@ -44,8 +44,8 @@ pub enum CompoundState {
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
-    pub plate_id: Uuid,
-    pub well_number: i16,
+    pub plate: Uuid,
+    pub well: i16,
     pub crystal_state: CrystalState,
     pub compound_state: CompoundState,
     pub timestamp: DateTime<Utc>,

--- a/backend/targeting/src/resolvers/image.rs
+++ b/backend/targeting/src/resolvers/image.rs
@@ -51,17 +51,17 @@ impl ImageQuery {
     async fn images(
         &self,
         ctx: &Context<'_>,
-        plate_id: Option<Uuid>,
-        well_number: Option<i16>,
+        plate: Option<Uuid>,
+        well: Option<i16>,
     ) -> async_graphql::Result<Vec<image::Model>> {
         subject_authorization!("xchemlab.targeting.read_image", ctx).await?;
         let database = ctx.data::<DatabaseConnection>()?;
         Ok(image::Entity::find()
-            .apply_if(plate_id, |query, plate_id| {
-                query.filter(image::Column::PlateId.eq(plate_id))
+            .apply_if(plate, |query, plate| {
+                query.filter(image::Column::Plate.eq(plate))
             })
-            .apply_if(well_number, |query, well_number| {
-                query.filter(image::Column::WellNumber.eq(well_number))
+            .apply_if(well, |query, well| {
+                query.filter(image::Column::Well.eq(well))
             })
             .all(database)
             .await?)
@@ -95,8 +95,8 @@ impl ImageMutation {
             .await?;
 
         let model = image::ActiveModel {
-            plate_id: sea_orm::ActiveValue::Set(well.plate),
-            well_number: sea_orm::ActiveValue::Set(well.well),
+            plate: sea_orm::ActiveValue::Set(well.plate),
+            well: sea_orm::ActiveValue::Set(well.well),
             timestamp: sea_orm::ActiveValue::Set(Utc::now()),
             operator_id: sea_orm::ActiveValue::Set(operator_id),
         };

--- a/backend/targeting/src/resolvers/prediction.rs
+++ b/backend/targeting/src/resolvers/prediction.rs
@@ -110,8 +110,8 @@ impl prediction_drop::ActiveModel {
 impl prediction::Model {
     async fn image(&self) -> Well {
         Well {
-            plate: self.plate_id,
-            well: self.well_number,
+            plate: self.plate,
+            well: self.well,
         }
     }
 
@@ -140,19 +140,19 @@ impl PredictionQuery {
         &self,
         ctx: &Context<'_>,
         id: Option<Uuid>,
-        plate_id: Option<Uuid>,
-        well_number: Option<i16>,
+        plate: Option<Uuid>,
+        well: Option<i16>,
         operator_id: Option<String>,
     ) -> async_graphql::Result<Vec<prediction::Model>> {
         subject_authorization!("xchemlab.targeting.read_prediction", ctx).await?;
         let database = ctx.data::<DatabaseConnection>()?;
         Ok(prediction::Entity::find()
             .apply_if(id, |query, id| query.filter(prediction::Column::Id.eq(id)))
-            .apply_if(plate_id, |query, plate_id| {
-                query.filter(prediction::Column::PlateId.eq(plate_id))
+            .apply_if(plate, |query, plate| {
+                query.filter(prediction::Column::Plate.eq(plate))
             })
-            .apply_if(well_number, |query, well_number| {
-                query.filter(prediction::Column::WellNumber.eq(well_number))
+            .apply_if(well, |query, well| {
+                query.filter(prediction::Column::Well.eq(well))
             })
             .apply_if(operator_id, |query, operator_id| {
                 query.filter(prediction::Column::OperatorId.eq(operator_id))
@@ -184,8 +184,8 @@ impl PredicitonMutation {
                 Box::pin(async move {
                     let prediction = prediction::Entity::insert(prediction::ActiveModel {
                         id: ActiveValue::Set(Uuid::new_v4()),
-                        plate_id: ActiveValue::Set(plate.plate),
-                        well_number: ActiveValue::Set(plate.well),
+                        plate: ActiveValue::Set(plate.plate),
+                        well: ActiveValue::Set(plate.well),
                         well_centroid_x: ActiveValue::Set(well_centroid.x),
                         well_centroid_y: ActiveValue::Set(well_centroid.y),
                         well_radius: ActiveValue::Set(well_radius),

--- a/backend/targeting/src/tables/image.rs
+++ b/backend/targeting/src/tables/image.rs
@@ -11,16 +11,16 @@ use sea_orm::{
 #[graphql(name = "Image", complex)]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub plate_id: Uuid,
+    pub plate: Uuid,
     #[sea_orm(primary_key)]
-    pub well_number: i16,
+    pub well: i16,
     pub timestamp: DateTime<Utc>,
     pub operator_id: String,
 }
 
 impl Model {
     pub fn object_key(&self) -> String {
-        format!("{}/{}", self.plate_id, self.well_number)
+        format!("{}/{}", self.plate, self.well)
     }
 }
 

--- a/backend/targeting/src/tables/prediction.rs
+++ b/backend/targeting/src/tables/prediction.rs
@@ -13,9 +13,9 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
     #[graphql(skip)]
-    pub plate_id: Uuid,
+    pub plate: Uuid,
     #[graphql(skip)]
-    pub well_number: i16,
+    pub well: i16,
     #[graphql(skip)]
     pub well_centroid_x: i32,
     #[graphql(skip)]
@@ -29,8 +29,8 @@ pub struct Model {
 pub enum Relation {
     #[sea_orm(
         belongs_to = "image::Entity",
-        from = "(Column::PlateId, Column::WellNumber)",
-        to = "(image::Column::PlateId, image::Column::WellNumber)"
+        from = "(Column::Plate, Column::Well)",
+        to = "(image::Column::Plate, image::Column::Well)"
     )]
     Well,
     #[sea_orm(has_many = "prediction_drop::Entity")]


### PR DESCRIPTION
Change the names of `plate_id` & `well_number` to `plate` & `well` to be consistent across the API